### PR TITLE
Register verbalize.is-a-fullstack.dev

### DIFF
--- a/domains/verbalize.is-a-fullstack.dev.json
+++ b/domains/verbalize.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "verbalize",
+
+    "owner": {
+        "email": "arnu515@protonmail.com"
+    },
+
+    "records": {
+        "A": ["71.71.27.27"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `verbalize.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).