### PR TITLE
Register rasofex.is-a-fullstack.dev

### DIFF
--- a/domains/rasofex.is-a-fullstack.dev.json
+++ b/domains/rasofex.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "rasofex",
+
+    "owner": {
+        "email": "rasofex@yandex.ru"
+    },
+
+    "records": {
+        "A": ["217.18.61.157"]
+    },
+
+    "proxied": true
+}


### PR DESCRIPTION
Added `rasofex.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).