### PR TITLE
Register madeirarent.is-a-fullstack.dev

### DIFF
--- a/domains/madeirarent.is-a-fullstack.dev.json
+++ b/domains/madeirarent.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "madeirarent",
+
+    "owner": {
+        "email": "wesley.generoso.95@gmail.com"
+    },
+
+    "records": {
+        "A": ["185.15.22.176"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `madeirarent.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).