### PR TITLE
Register makopog.is-a-frontend.dev

### DIFF
--- a/domains/makopog.is-a-frontend.dev.json
+++ b/domains/makopog.is-a-frontend.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-frontend.dev",
+    "subdomain": "makopog",
+
+    "owner": {
+        "email": "martixik@protonmail.com"
+    },
+
+    "records": {
+        "A": ["76.76.21.21"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `makopog.is-a-frontend.dev` using the [CLI](https://cli.freesubdomains.org).