### PR TITLE
Register halo.is-a-fullstack.dev

### DIFF
--- a/domains/halo.is-a-fullstack.dev.json
+++ b/domains/halo.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "halo",
+
+    "owner": {
+        "email": "ethan.james.hume.6521@googlemail.com"
+    },
+
+    "records": {
+        "A": ["1.0.0.1"]
+    },
+
+    "proxied": true
+}


### PR DESCRIPTION
Added `halo.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).