### PR TITLE
Register testopenbsd.is-a-backend.dev

### DIFF
--- a/domains/testopenbsd.is-a-backend.dev.json
+++ b/domains/testopenbsd.is-a-backend.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-backend.dev",
+    "subdomain": "testopenbsd",
+
+    "owner": {
+        "email": "soubheeknath@gmail.com"
+    },
+
+    "records": {
+        "A": ["1"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `testopenbsd.is-a-backend.dev` using the [CLI](https://cli.freesubdomains.org).