### PR TITLE
Register matiix310.is-a-fullstack.dev

### DIFF
--- a/domains/matiix310.is-a-fullstack.dev.json
+++ b/domains/matiix310.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "matiix310",
+
+    "owner": {
+        "email": "lucas.stephan.12@outlook.fr"
+    },
+
+    "records": {
+        "CNAME": "b65c431742c2982a7b0c1450bd45fb58.ipv4.tcpshield.com"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `matiix310.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).