### PR TITLE
Register danieltorres.is-a-fullstack.dev

### DIFF
--- a/domains/danieltorres.is-a-fullstack.dev.json
+++ b/domains/danieltorres.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "danieltorres",
+
+    "owner": {
+        "email": "danielandrestv@hotmail.com"
+    },
+
+    "records": {
+        "CNAME": "https://centrocultural-5pbd5rxzp-githuber95.vercel.app"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `danieltorres.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).