### PR TITLE
Update jeff.is-a-fullstack.dev.json to point to github

### DIFF
--- a/domains/jeff.is-a-fullstack.dev.json
+++ b/domains/jeff.is-a-fullstack.dev.json
@@ -7,7 +7,7 @@
     },
 
     "records": {
-        "CNAME": "jeff-tian.netlify.app"
+        "CNAME": "jeff-tian.github.io"
     },
 
     "proxied": false


### PR DESCRIPTION
As failed to create this PR using CLI, I edited the previous reverted one and create PR manually.

```
 Free Domains  v1.1.8 CLI
Register a free subdomain with Free Domains using your command line.

Username: Jeff-Tian
Email: jeff.tian@outlook.com

(node:60672) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
✔ What domain do you want your subdomain to use? › is-a-fullstack.dev
✔ What subdomain would you like? … jeff
✔ What type of record do you want to use? › CNAME
✔ What should the value of the record be? … jeff-tian.github.io
✔ Should the record be proxied through Cloudflare? › No (recommended)

✖ UNHANDLED ERROR
✖ ERROR → Error
ℹ REASON → HttpError: Invalid request.

"sha" wasn't supplied.
ℹ ERROR STACK ↓
 Error: HttpError: Invalid request.

"sha" wasn't supplied.
    at /Users/cnjeftia/.nvm/versions/node/v18.3.0/lib/node_modules/@free-domains/cli/src/functions/register.js:95:31
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.register (/Users/cnjeftia/.nvm/versions/node/v18.3.0/lib/node_modules/@free-domains/cli/src/functions/register.js:89:5)
```

<!-- To make our job easier, please spend time to review your application before submitting. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The `CNAME` record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.

## Description
<!-- Please provide a description below of what you will be using the domain for. -->

My profile page and my blog posts

## Website Link / Preview
<!-- Please provide a link or preview of your website below. -->

https://jeff-tian.jiwai.win/
