### PR TITLE
Register greenerworld.is-a-fullstack.dev

### DIFF
--- a/domains/greenerworld.is-a-fullstack.dev.json
+++ b/domains/greenerworld.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "greenerworld",
+
+    "owner": {
+        "email": "bzhe0015@student.monash.edu"
+    },
+
+    "records": {
+        "CNAME": "greener.com"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `greenerworld.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).