### PR TITLE
Register jsdhami.is-a-fullstack.dev

### DIFF
--- a/domains/jsdhami.is-a-fullstack.dev.json
+++ b/domains/jsdhami.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "jsdhami",
+
+    "owner": {
+        "email": "info@jsdhami.com.np"
+    },
+
+    "records": {
+        "CNAME": "jsdhami.github.io"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `jsdhami.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).