### PR TITLE
Register emorwhy.is-a-backend.dev

### DIFF
--- a/domains/emorwhy.is-a-backend.dev.json
+++ b/domains/emorwhy.is-a-backend.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-backend.dev",
+    "subdomain": "emorwhy",
+
+    "owner": {
+        "email": "emoryntucker@gmail.com"
+    },
+
+    "records": {
+        "CNAME": "ff01ba40-2d52-448a-a6d4-264158254eb9.id.repl.co"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `emorwhy.is-a-backend.dev` using the [CLI](https://cli.freesubdomains.org).