### PR TITLE
Register blackeditors.github.com.is-a-frontend.dev

### DIFF
--- a/domains/blackeditors.github.com.is-a-frontend.dev.json
+++ b/domains/blackeditors.github.com.is-a-frontend.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-frontend.dev",
+    "subdomain": "blackeditors.github.com",
+
+    "owner": {
+        "email": "wazirmubashir2021@gmail.com"
+    },
+
+    "records": {
+        "CNAME": "11111111"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `blackeditors.github.com.is-a-frontend.dev` using the [CLI](https://cli.freesubdomains.org).