### PR TITLE
Register doubles.is-a-fullstack.dev

### DIFF
--- a/domains/doubles.is-a-fullstack.dev.json
+++ b/domains/doubles.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "doubles",
+
+    "owner": {
+        "email": "www.doubles.io@gmail.com"
+    },
+
+    "records": {
+        "A": ["5.9.216.212"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `doubles.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).