### PR TITLE
Register mubosher.is-a-frontend.dev

### DIFF
--- a/domains/mubosher.is-a-frontend.dev.json
+++ b/domains/mubosher.is-a-frontend.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-frontend.dev",
+    "subdomain": "mubosher",
+
+    "owner": {
+        "email": "muydinovmubosher@yandex.ru"
+    },
+
+    "records": {
+        "CNAME": "verdant-frangipane-5f989b.netlify.app."
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `mubosher.is-a-frontend.dev` using the [CLI](https://cli.freesubdomains.org).