### PR TITLE
Register serif.is-a-backend.dev

### DIFF
--- a/domains/serif.is-a-backend.dev.json
+++ b/domains/serif.is-a-backend.dev.json
@@ -1,0 +1,11 @@
+{
+    "domain": "is-a-backend.dev",
+    "subdomain": "serif",
+    "owner": {
+        "email": "serifdomain@turtlespog64.33mail.com"
+    },
+    "records": {
+        "A": ["49.12.220.124"]
+    },
+    "proxied": false
+}


### PR DESCRIPTION
Added serif.is-a-backend.dev using the [CLI](https://cli.freesubdomains.org/).