### PR TITLE
Register daim.is-a-fullstack.dev

### DIFF
--- a/domains/daim.is-a-fullstack.dev.json
+++ b/domains/daim.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "daim",
+
+    "owner": {
+        "email": "daimdev6@gmail.com"
+    },
+
+    "records": {
+        "A": ["49.36.200.75"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `daim.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).