### PR TITLE
Register svirl.is-a-frontend.dev

### DIFF
--- a/domains/svirl.is-a-frontend.dev.json
+++ b/domains/svirl.is-a-frontend.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-frontend.dev",
+    "subdomain": "svirl",
+
+    "owner": {
+        "email": "shimkonn@gmail.com"
+    },
+
+    "records": {
+        "A": ["165.227.128.252"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `svirl.is-a-frontend.dev` using the [CLI](https://cli.freesubdomains.org).