### PR TITLE
Register eng-software.is-a-fullstack.dev

### DIFF
--- a/domains/eng-software.is-a-fullstack.dev.json
+++ b/domains/eng-software.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "eng-software",
+
+    "owner": {
+        "email": "rodrigues.filipealexandre2003@gmail.com"
+    },
+
+    "records": {
+        "A": [""]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `eng-software.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).