### PR TITLE
Register lynic.is-a-frontend.dev

### DIFF
--- a/domains/lynic.is-a-frontend.dev.json
+++ b/domains/lynic.is-a-frontend.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-frontend.dev",
+    "subdomain": "lynic",
+
+    "owner": {
+        "email": "nuffimail33@gmail.com"
+    },
+
+    "records": {
+        "CNAME": "lynicv.github.io"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `lynic.is-a-frontend.dev` using the [CLI](https://cli.freesubdomains.org).