### PR TITLE
Register 68.183.246.92.is-a-fullstack.dev

### DIFF
--- a/domains/68.183.246.92.is-a-fullstack.dev.json
+++ b/domains/68.183.246.92.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "68.183.246.92",
+
+    "owner": {
+        "email": "jonathanpkatumba@gmail.com"
+    },
+
+    "records": {
+        "A": ["68.183.246.92"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `68.183.246.92.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).