### PR TITLE
Register gitlawl.is-a-backend.dev

### DIFF
--- a/domains/gitlawl.is-a-backend.dev.json
+++ b/domains/gitlawl.is-a-backend.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-backend.dev",
+    "subdomain": "gitlawl",
+
+    "owner": {
+        "email": "adam@braap.pw"
+    },
+
+    "records": {
+        "A": ["1.1.1.1"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `gitlawl.is-a-backend.dev` using the [CLI](https://cli.freesubdomains.org).