### PR TITLE
Register hfxfreelancers.is-a-fullstack.dev

### DIFF
--- a/domains/hfxfreelancers.is-a-fullstack.dev.json
+++ b/domains/hfxfreelancers.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "hfxfreelancers",
+
+    "owner": {
+        "email": "gopalkrishna.naredla@gmail.com"
+    },
+
+    "records": {
+        "A": [""]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `hfxfreelancers.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).