### PR TITLE
Register msb-tag.is-a-fullstack.dev

### DIFF
--- a/domains/msb-tag.is-a-fullstack.dev.json
+++ b/domains/msb-tag.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "msb-tag",
+
+    "owner": {
+        "email": "t.duchow10@Gmail.com"
+    },
+
+    "records": {
+        "A": ["134.255.218.204"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `msb-tag.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).