### PR TITLE
Register adil.is-a-fullstack.dev

### DIFF
--- a/domains/adil.is-a-fullstack.dev.json
+++ b/domains/adil.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "adil",
+
+    "owner": {
+        "email": "adilelghazzali.dev@gmail.com"
+    },
+
+    "records": {
+        "CNAME": "is-a-fullstack.dev"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `adil.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).