### PR TITLE
Register heaven.is-a-backend.dev

### DIFF
--- a/domains/heaven.is-a-backend.dev.json
+++ b/domains/heaven.is-a-backend.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-backend.dev",
+    "subdomain": "heaven",
+
+    "owner": {
+        "email": "Keremlog@gmail.com"
+    },
+
+    "records": {
+        "A": ["45.83.245.57"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `heaven.is-a-backend.dev` using the [CLI](https://cli.freesubdomains.org).