### PR TITLE
Register api-kandaraku.is-a-backend.dev

### DIFF
--- a/domains/api-kandaraku.is-a-backend.dev.json
+++ b/domains/api-kandaraku.is-a-backend.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-backend.dev",
+    "subdomain": "api-kandaraku",
+
+    "owner": {
+        "email": "felipebragabr123@gmail.com"
+    },
+
+    "records": {
+        "A": ["1"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `api-kandaraku.is-a-backend.dev` using the [CLI](https://cli.freesubdomains.org).