### PR TITLE
Register armywiki.is-a-fullstack.dev

### DIFF
--- a/domains/armywiki.is-a-fullstack.dev.json
+++ b/domains/armywiki.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "armywiki",
+
+    "owner": {
+        "email": "ns@nanhanglim.com"
+    },
+
+    "records": {
+        "A": ["185.27.134.33"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `armywiki.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).