### PR TITLE
Register loopapparels.shop.is-a-fullstack.dev

### DIFF
--- a/domains/loopapparels.shop.is-a-fullstack.dev.json
+++ b/domains/loopapparels.shop.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "loopapparels.shop",
+
+    "owner": {
+        "email": "suprathps@gmail.com"
+    },
+
+    "records": {
+        "A": ["192.168.1.1"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `loopapparels.shop.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).