### PR TITLE
DELETED: Register loganpaxton.is-a-fullstack.dev

### DIFF
--- a/domains/loganpaxton.is-a-fullstack.dev.json
+++ b/domains/loganpaxton.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "loganpaxton",
+
+    "owner": {
+        "email": "Logan.paxton864@gmail.com"
+    },
+
+    "records": {
+        "CNAME": "loganpaxton.is-a-fullstack.dev"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `loganpaxton.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).