### PR TITLE
Register hjcloud.is-a-fullstack.dev

### DIFF
--- a/domains/hjcloud.is-a-fullstack.dev.json
+++ b/domains/hjcloud.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "hjcloud",
+
+    "owner": {
+        "email": "hasifjalil@gmail.com"
+    },
+
+    "records": {
+        "CNAME": "hasifjalil.github.io"
+    },
+
+    "proxied": true
+}


### PR DESCRIPTION
Added `hjcloud.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).