### PR TITLE
Register foolish.is-a-fullstack.dev

### DIFF
--- a/domains/foolish.is-a-fullstack.dev.json
+++ b/domains/foolish.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "foolish",
+
+    "owner": {
+        "email": "santrialanwari@gmail.com"
+    },
+
+    "records": {
+        "A": ["139.59.255.229"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `foolish.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).