### PR TITLE
Register brise.is-a-fullstack.dev

### DIFF
--- a/domains/brise.is-a-fullstack.dev.json
+++ b/domains/brise.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "brise",
+
+    "owner": {
+        "email": "mohabenhayoun56@gmail.com"
+    },
+
+    "records": {
+        "A": ["1.1.1.1"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `brise.is-a-fullstack.dev` using the [CLI](https://cli.freesubdomains.org).