### PR TITLE
Register portainer.is-a-fullstack.dev

### DIFF
--- a/domains/portainer.is-a-fullstack.dev.json
+++ b/domains/portainer.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "portainer",
+
+    "owner": {
+        "email": "halit.dogmen@ceng.deu.edu.tr"
+    },
+
+    "records": {
+        "A": ["95.173.236.22"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `portainer.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).