### PR TITLE
Register mono-rates-bot.is-a-fullstack.dev

### DIFF
--- a/domains/mono-rates-bot.is-a-fullstack.dev.json
+++ b/domains/mono-rates-bot.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "mono-rates-bot",
+
+    "owner": {
+        "email": "koretskiyav@gmail.com"
+    },
+
+    "records": {
+        "A": ["64.226.100.103"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `mono-rates-bot.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).