### PR TITLE
Register vmiss-hk.zhwxp.is-a-fullstack.dev

### DIFF
--- a/domains/vmiss-hk.zhwxp.is-a-fullstack.dev.json
+++ b/domains/vmiss-hk.zhwxp.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "vmiss-hk.zhwxp",
+
+    "owner": {
+        "email": "zhwxp@live.com"
+    },
+
+    "records": {
+        "A": ["38.207.164.25"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `vmiss-hk.zhwxp.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).