### PR TITLE
Register aquaconpoderes.is-a-fullstack.dev

### DIFF
--- a/domains/aquaconpoderes.is-a-fullstack.dev.json
+++ b/domains/aquaconpoderes.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "aquaconpoderes",
+
+    "owner": {
+        "email": "elrobotdelpueblo@gmail.com"
+    },
+
+    "records": {
+        "AAAA": ["https://26a9eb-7.myshopify.com/"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `aquaconpoderes.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).