### PR TITLE
Register editorial.is-a-fullstack.dev

### DIFF
--- a/domains/editorial.is-a-fullstack.dev.json
+++ b/domains/editorial.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "editorial",
+
+    "owner": {
+        "email": "rhoconlinux@gmail.com"
+    },
+
+    "records": {
+        "CNAME": "rhoconlinux.github.io/editorial"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `editorial.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).