### PR TITLE
Register freedom-liwejroiwje.is-a-fullstack.dev

### DIFF
--- a/domains/freedom-liwejroiwje.is-a-fullstack.dev.json
+++ b/domains/freedom-liwejroiwje.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "freedom-liwejroiwje",
+
+    "owner": {
+        "email": "mahdikarami1000@gmail.com"
+    },
+
+    "records": {
+        "A": ["82.115.19.194"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `freedom-liwejroiwje.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).