### PR TITLE
Register mossfoundry.is-a-fullstack.dev

### DIFF
--- a/domains/mossfoundry.is-a-fullstack.dev.json
+++ b/domains/mossfoundry.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "mossfoundry",
+
+    "owner": {
+        "email": "glabusjakub@gmail.com"
+    },
+
+    "records": {
+        "A": ["130.162.168.178"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `mossfoundry.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).