### PR TITLE
Register dooph.is-a-fullstack.dev

### DIFF
--- a/domains/dooph.is-a-fullstack.dev.json
+++ b/domains/dooph.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "dooph",
+
+    "owner": {
+        "email": "dopham.bkit@gmail.com"
+    },
+
+    "records": {
+        "AAAA": ["fe80::215:5dff:fec9:ecce"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `dooph.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).