### PR TITLE
Register avengers-sonarqube.is-a-fullstack.dev

### DIFF
--- a/domains/avengers-sonarqube.is-a-fullstack.dev.json
+++ b/domains/avengers-sonarqube.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "avengers-sonarqube",
+
+    "owner": {
+        "email": "hugh.hoang@gmail.com"
+    },
+
+    "records": {
+        "A": ["20.53.134.188"]
+    },
+
+    "proxied": false
+}

--- a/domains/avengers-sonarqube.is-a-fullstack.dev.json
+++ b/domains/avengers-sonarqube.is-a-fullstack.dev.json
@@ -7,7 +7,15 @@
     },
 
     "records": {
-        "A": ["20.53.134.188"]
+        "A": [
+            "20.53.134.188"
+        ],
+        "TXT": [
+            {
+                "name": "asuid",
+                "value": "2ADF2B3BF4F2D427644C6A908F1607F17C2A1AAE36C1A5E86A6FDFD7B56B2149"
+            }
+        ]
     },
 
     "proxied": false


### PR DESCRIPTION
Added `avengers-sonarqube.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).