### PR TITLE
Register ghostcoder67.is-a-fullstack.dev

### DIFF
--- a/domains/ghostcoder67.is-a-fullstack.dev.json
+++ b/domains/ghostcoder67.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "ghostcoder67",
+
+    "owner": {
+        "email": "ayannaseer70065988@gmail.com"
+    },
+
+    "records": {
+        "CNAME": "https://ghost67.netlify.app"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `ghostcoder67.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).