### PR TITLE
Register syruponwaffles.is-a-fullstack.dev

### DIFF
--- a/domains/syruponwaffles.is-a-fullstack.dev.json
+++ b/domains/syruponwaffles.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "syruponwaffles",
+
+    "owner": {
+        "email": "nicholaskor@hotmail.com"
+    },
+
+    "records": {
+        "CNAME": "https://github.com/syruponwaffles/raycaster"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `syruponwaffles.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).