### PR TITLE
Register terabox-dl.is-a-fullstack.dev

### DIFF
--- a/domains/terabox-dl.is-a-fullstack.dev.json
+++ b/domains/terabox-dl.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "terabox-dl",
+
+    "owner": {
+        "email": "lipanghadai@gmail.com"
+    },
+
+    "records": {
+        "CNAME": "jinix6.github.io/terabox-downloader"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `terabox-dl.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).