### PR TITLE
Register mosaphir.is-a-fullstack.dev

### DIFF
--- a/domains/mosaphir.is-a-fullstack.dev.json
+++ b/domains/mosaphir.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "mosaphir",
+
+    "owner": {
+        "email": "skdm0111@gmail.com"
+    },
+
+    "records": {
+        "CNAME": "mosaphir.github.io"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `mosaphir.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).