### PR TITLE
Register devblog.is-a-fullstack.dev

### DIFF
--- a/domains/devblog.is-a-fullstack.dev.json
+++ b/domains/devblog.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "devblog",
+
+    "owner": {
+        "email": "amuyunzubq@gmail.com"
+    },
+
+    "records": {
+        "CNAME": "1000"
+    },
+
+    "proxied": true
+}


### PR DESCRIPTION
Added `devblog.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).