### PR TITLE
Register requestinfo-funding-dojo.is-a-fullstack.dev

### DIFF
--- a/domains/requestinfo-funding-dojo.is-a-fullstack.dev.json
+++ b/domains/requestinfo-funding-dojo.is-a-fullstack.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-a-fullstack.dev",
+    "subdomain": "requestinfo-funding-dojo",
+
+    "owner": {
+        "email": "dojo.info@aol.com"
+    },
+
+    "records": {
+        "CNAME": "inforequest.github.io/dojo-funding/"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `requestinfo-funding-dojo.is-a-fullstack.dev` using the [CLI](https://www.npmjs.com/package/@free-domains/cli).